### PR TITLE
download page tweak

### DIFF
--- a/dragondropweb/src/app/app.component.html
+++ b/dragondropweb/src/app/app.component.html
@@ -9,7 +9,7 @@
         <a mat-button class="menu-item" routerLink="about">About</a>
         <a mat-button class="menu-item" href="https://github.com/dragondropteam/desktop/releases" target="_blank">Download</a>
         <a mat-button class="menu-item" routerLink="instructions">Instructions</a>
-        <a mat-button class="menu-item" routerLink="documentation">Documentation</a>
+        <a mat-button class="menu-item" href="https://dragondropteam.github.io/assets/documentation/index.html" target="_blank">Documentation</a>
         <!--    <button
       mat-button
       class="menu-item"

--- a/dragondropweb/src/app/app.component.html
+++ b/dragondropweb/src/app/app.component.html
@@ -3,14 +3,14 @@
   -->
 
 <div class="app">
-  <nav class="menu">
-    <img class="dragon" src="../../assets/background.png">
-    <a mat-button class="menu-item" routerLink="">Home</a>
-    <a mat-button class="menu-item" routerLink="about">About</a>
-    <a mat-button class="menu-item" href="https://github.com/dragondropteam/desktop/releases">Download</a>
-    <a mat-button class="menu-item" routerLink="instructions">Instructions</a>
-    <a mat-button class="menu-item" routerLink="documentation">Documentation</a>
-<!--    <button
+    <nav class="menu">
+        <img class="dragon" src="../../assets/background.png">
+        <a mat-button class="menu-item" routerLink="">Home</a>
+        <a mat-button class="menu-item" routerLink="about">About</a>
+        <a mat-button class="menu-item" href="https://github.com/dragondropteam/desktop/releases" target="_blank">Download</a>
+        <a mat-button class="menu-item" routerLink="instructions">Instructions</a>
+        <a mat-button class="menu-item" routerLink="documentation">Documentation</a>
+        <!--    <button
       mat-button
       class="menu-item"
       *ngIf="!auth.isAuthenticated()"
@@ -28,7 +28,7 @@
 
     <a mat-button class="admin" routerLink="admin" *ngIf="auth.isAdmin()">Admin</a>-->
 
-  </nav>
-  <router-outlet></router-outlet>
+    </nav>
+    <router-outlet></router-outlet>
 </div>
 <footer></footer>


### PR DESCRIPTION
(I forgot to push this, apparently)
The documentation page is obsolete - the button now redirects to the documentation in a new tab.